### PR TITLE
remove dotenv

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,6 @@
     "@noble/ciphers": "^1.0.0",
     "@prisma/client": "5.22.0",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
     "effect": "^3.12.2",
     "express": "^5.0.1",
     "siwe": "^2.3.2",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,9 +1,8 @@
 import { Identity, Messages, SpaceEvents, Utils } from '@graphprotocol/hypergraph';
 import cors from 'cors';
-import 'dotenv/config';
-import { parse } from 'node:url';
 import { Effect, Exit, Schema } from 'effect';
 import express, { type Request, type Response } from 'express';
+import { parse } from 'node:url';
 import { SiweMessage } from 'siwe';
 import type { Hex } from 'viem';
 import WebSocket, { WebSocketServer } from 'ws';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
       effect:
         specifier: ^3.12.2
         version: 3.12.2


### PR DESCRIPTION
dotenv is not needed with `bun` during development and in production we don't want it to be there

hint by @fubhy 