### PR TITLE
cleanup deps

### DIFF
--- a/packages/hypergraph/package.json
+++ b/packages/hypergraph/package.json
@@ -22,9 +22,7 @@
     "test": "vitest"
   },
   "devDependencies": {
-    "@types/uuid": "^10.0.0",
-    "@vitejs/plugin-react": "^4.3.4",
-    "jsdom": "^26.0.0"
+    "@types/uuid": "^10.0.0"
   },
   "dependencies": {
     "@automerge/automerge": "^v2.2.9-alpha.3",

--- a/packages/hypergraph/vitest.config.ts
+++ b/packages/hypergraph/vitest.config.ts
@@ -1,12 +1,6 @@
-import react from '@vitejs/plugin-react';
 import { type UserConfigExport, mergeConfig } from 'vitest/config';
 import shared from '../../vitest.shared.js';
 
-const config: UserConfigExport = {
-  plugins: [react()],
-  test: {
-    environment: 'jsdom',
-  },
-};
+const config: UserConfigExport = {};
 
 export default mergeConfig(shared, config);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,12 +260,6 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.7)(tsx@4.19.2)(yaml@2.7.0))
-      jsdom:
-        specifier: ^26.0.0
-        version: 26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     publishDirectory: publish
 
   packages/hypergraph-react:


### PR DESCRIPTION
@cmwhited noticed we don't `jsdom` anymore https://github.com/graphprotocol/hypergraph/pull/112#discussion_r1924298223

I cleaned up the react vite setup in there as well. The core should be React indepedent.