### PR TITLE
improve naming of identity/keys

### DIFF
--- a/packages/hypergraph-react/src/HypergraphAuthContext.tsx
+++ b/packages/hypergraph-react/src/HypergraphAuthContext.tsx
@@ -145,7 +145,7 @@ export function HypergraphAuthProvider({
     }
   }
 
-  async function loginWithKeys(keys: Identity.Keys, accountId: Address) {
+  async function loginWithKeys(keys: Identity.IdentityKeys, accountId: Address) {
     const sessionToken = Identity.loadSyncServerSessionToken(storage, accountId);
     if (sessionToken) {
       // use whoami to check if the session token is still valid
@@ -213,7 +213,7 @@ export function HypergraphAuthProvider({
   }
 
   async function signup(signer: Identity.Signer, accountId: Address) {
-    const keys = Identity.createIdentity();
+    const keys = Identity.createIdentityKeys();
     const { ciphertext, nonce } = await Identity.encryptIdentity(signer, accountId, keys);
     const { accountProof, keyProof } = await Identity.proveIdentityOwnership(signer, accountId, keys);
 
@@ -368,5 +368,5 @@ type HypergraphAuthState = {
   authenticated: boolean;
   accountId: Address | null;
   sessionToken: string | null;
-  keys: Identity.Keys | null;
+  keys: Identity.IdentityKeys | null;
 };

--- a/packages/hypergraph/src/identity/auth-storage.ts
+++ b/packages/hypergraph/src/identity/auth-storage.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect';
 import { deserialize, serialize } from '../messages/index.js';
-import { type Keys, KeysSchema, type Storage } from './types.js';
+import { type IdentityKeys, KeysSchema, type Storage } from './types.js';
 
 export const getEnv = (): 'dev' | 'production' | 'local' => {
   return 'dev';
@@ -14,7 +14,7 @@ export const buildKeysStorageKey = (walletAddress: string) =>
 export const buildSessionTokenStorageKey = (walletAddress: string) =>
   walletAddress ? `hypergraph:${getEnv()}:session-token:${walletAddress}` : '';
 
-export const loadKeys = (storage: Storage, walletAddress: string): Keys | null => {
+export const loadKeys = (storage: Storage, walletAddress: string): IdentityKeys | null => {
   const accessKey = buildKeysStorageKey(walletAddress);
   const val = storage.getItem(accessKey);
   if (!val) {
@@ -29,7 +29,7 @@ export const loadKeys = (storage: Storage, walletAddress: string): Keys | null =
   };
 };
 
-export const storeKeys = (storage: Storage, walletAddress: string, keys: Keys) => {
+export const storeKeys = (storage: Storage, walletAddress: string, keys: IdentityKeys) => {
   const keysMsg = serialize(Schema.encodeSync(KeysSchema)(keys));
   storage.setItem(buildKeysStorageKey(walletAddress), keysMsg);
 };

--- a/packages/hypergraph/src/identity/create-identity-keys.ts
+++ b/packages/hypergraph/src/identity/create-identity-keys.ts
@@ -2,9 +2,9 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 
 import { generateKeypair } from '../key/index.js';
 import { bytesToHex } from '../utils/index.js';
-import type { Keys } from './types.js';
+import type { IdentityKeys } from './types.js';
 
-export const createIdentity = (): Keys => {
+export const createIdentityKeys = (): IdentityKeys => {
   // generate a random private key for encryption
   const { publicKey: encryptionPublicKey, secretKey: encryptionPrivateKey } = generateKeypair();
   // generate a random private key for signing

--- a/packages/hypergraph/src/identity/identity-encryption.ts
+++ b/packages/hypergraph/src/identity/identity-encryption.ts
@@ -4,7 +4,7 @@ import type { Hex } from 'viem';
 import { verifyMessage } from 'viem';
 
 import { bytesToHex, hexToBytes } from '../utils/index.js';
-import type { Keys, Signer } from './types.js';
+import type { IdentityKeys, Signer } from './types.js';
 
 // Adapted from the XMTP approach to encrypt keys
 // See: https://github.com/xmtp/xmtp-js/blob/8d6e5a65813902926baac8150a648587acbaad92/sdks/js-sdk/src/keystore/providers/NetworkKeyManager.ts#L79-L116
@@ -17,7 +17,7 @@ const signatureMessage = (nonce: Uint8Array): string => {
 export const encryptIdentity = async (
   signer: Signer,
   accountId: string,
-  keys: Keys,
+  keys: IdentityKeys,
 ): Promise<{ ciphertext: string; nonce: string }> => {
   const nonce = randomBytes(32);
   const message = signatureMessage(nonce);
@@ -51,7 +51,7 @@ export const decryptIdentity = async (
   accountId: string,
   ciphertext: string,
   nonce: string,
-): Promise<Keys> => {
+): Promise<IdentityKeys> => {
   const message = signatureMessage(hexToBytes(nonce));
   const signature = (await signer.signMessage(message)) as Hex;
 

--- a/packages/hypergraph/src/identity/index.ts
+++ b/packages/hypergraph/src/identity/index.ts
@@ -1,5 +1,5 @@
 export * from './auth-storage.js';
-export * from './create-identity.js';
+export * from './create-identity-keys.js';
 export * from './identity-encryption.js';
 export * from './prove-ownership.js';
 export * from './types.js';

--- a/packages/hypergraph/src/identity/prove-ownership.ts
+++ b/packages/hypergraph/src/identity/prove-ownership.ts
@@ -2,7 +2,7 @@ import { type Hex, verifyMessage } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { publicKeyToAddress } from '../utils/index.js';
-import type { Keys, Signer } from './types.js';
+import type { IdentityKeys, Signer } from './types.js';
 
 export const getAccountProofMessage = (accountId: string, publicKey: string): string => {
   return `This message proves I am the owner of the account ${accountId} and the public key ${publicKey}`;
@@ -15,7 +15,7 @@ export const getKeyProofMessage = (accountId: string, publicKey: string): string
 export const proveIdentityOwnership = async (
   signer: Signer,
   accountId: string,
-  keys: Keys,
+  keys: IdentityKeys,
 ): Promise<{ accountProof: string; keyProof: string }> => {
   const publicKey = keys.signaturePublicKey;
   const accountProofMessage = getAccountProofMessage(accountId, publicKey);

--- a/packages/hypergraph/src/identity/types.ts
+++ b/packages/hypergraph/src/identity/types.ts
@@ -13,7 +13,7 @@ export type Signer = {
   signMessage: SignMessage;
 };
 
-export type Keys = {
+export type IdentityKeys = {
   encryptionPublicKey: string;
   encryptionPrivateKey: string;
   signaturePublicKey: string;
@@ -29,10 +29,6 @@ export const KeysSchema = Schema.Struct({
 
 export type KeysSchema = Schema.Schema.Type<typeof KeysSchema>;
 
-export type Identity = {
+export type Identity = IdentityKeys & {
   accountId: string;
-  encryptionPublicKey: string;
-  encryptionPrivateKey: string;
-  signaturePublicKey: string;
-  signaturePrivateKey: string;
 };


### PR DESCRIPTION
solves #80 

Background: Initially wanted to name it just `Keys`, but then realized we have other keys as well and probably easier for everyone if we are explicit about them