### PR TITLE
use accountId as primary identifier

### DIFF
--- a/packages/hypergraph/src/space-events/create-invitation.ts
+++ b/packages/hypergraph/src/space-events/create-invitation.ts
@@ -9,8 +9,6 @@ type Params = {
   previousEventHash: string;
   invitee: {
     accountId: string;
-    signaturePublicKey: string;
-    encryptionPublicKey: string;
   };
 };
 
@@ -22,11 +20,7 @@ export const createInvitation = ({
   const transaction = {
     id: generateId(),
     type: 'create-invitation' as const,
-    ciphertext: '',
-    nonce: '',
     inviteeAccountId: invitee.accountId,
-    signaturePublicKey: invitee.signaturePublicKey,
-    encryptionPublicKey: invitee.encryptionPublicKey,
     previousEventHash,
   };
   const encodedTransaction = stringToUint8Array(canonicalize(transaction));

--- a/packages/hypergraph/src/space-events/create-space.ts
+++ b/packages/hypergraph/src/space-events/create-space.ts
@@ -13,8 +13,6 @@ export const createSpace = ({ author }: Params): Effect.Effect<CreateSpaceEvent,
     type: 'create-space' as const,
     id: generateId(),
     creatorAccountId: author.accountId,
-    creatorSignaturePublicKey: author.signaturePublicKey,
-    creatorEncryptionPublicKey: author.encryptionPublicKey,
   };
   const encodedTransaction = stringToUint8Array(canonicalize(transaction));
   const signature = secp256k1

--- a/packages/hypergraph/src/space-events/types.ts
+++ b/packages/hypergraph/src/space-events/types.ts
@@ -1,9 +1,17 @@
 import * as Schema from 'effect/Schema';
 
+export const EventAuthor = Schema.Struct({
+  accountId: Schema.String,
+  // must be validated if it belongs to the accountId before being used
+  // Note: could be removed, but also might be useful to keep around in case accounts rotate their keys
+  publicKey: Schema.String,
+  signature: Schema.String,
+});
+
+export type EventAuthor = Schema.Schema.Type<typeof Author>;
+
 export const SpaceMember = Schema.Struct({
   accountId: Schema.String,
-  signaturePublicKey: Schema.String,
-  encryptionPublicKey: Schema.String,
   role: Schema.Union(Schema.Literal('admin'), Schema.Literal('member')),
 });
 
@@ -11,8 +19,6 @@ export type SpaceMember = Schema.Schema.Type<typeof SpaceMember>;
 
 export const SpaceInvitation = Schema.Struct({
   inviteeAccountId: Schema.String,
-  signaturePublicKey: Schema.String,
-  encryptionPublicKey: Schema.String,
 });
 
 export type SpaceInvitation = Schema.Schema.Type<typeof SpaceInvitation>;
@@ -32,14 +38,8 @@ export const CreateSpaceEvent = Schema.Struct({
     type: Schema.Literal('create-space'),
     id: Schema.String,
     creatorAccountId: Schema.String,
-    creatorSignaturePublicKey: Schema.String,
-    creatorEncryptionPublicKey: Schema.String,
   }),
-  author: Schema.Struct({
-    accountId: Schema.String,
-    publicKey: Schema.String,
-    signature: Schema.String,
-  }),
+  author: EventAuthor,
 });
 
 export type CreateSpaceEvent = Schema.Schema.Type<typeof CreateSpaceEvent>;
@@ -50,11 +50,7 @@ export const DeleteSpaceEvent = Schema.Struct({
     id: Schema.String,
     previousEventHash: Schema.String,
   }),
-  author: Schema.Struct({
-    accountId: Schema.String,
-    publicKey: Schema.String,
-    signature: Schema.String,
-  }),
+  author: EventAuthor,
 });
 
 export type DeleteSpaceEvent = Schema.Schema.Type<typeof DeleteSpaceEvent>;
@@ -63,18 +59,10 @@ export const CreateInvitationEvent = Schema.Struct({
   transaction: Schema.Struct({
     type: Schema.Literal('create-invitation'),
     id: Schema.String,
-    ciphertext: Schema.String,
-    nonce: Schema.String,
     inviteeAccountId: Schema.String,
-    signaturePublicKey: Schema.String,
-    encryptionPublicKey: Schema.String,
     previousEventHash: Schema.String,
   }),
-  author: Schema.Struct({
-    accountId: Schema.String,
-    publicKey: Schema.String,
-    signature: Schema.String,
-  }),
+  author: EventAuthor,
 });
 
 export type CreateInvitationEvent = Schema.Schema.Type<typeof CreateInvitationEvent>;
@@ -85,11 +73,7 @@ export const AcceptInvitationEvent = Schema.Struct({
     type: Schema.Literal('accept-invitation'),
     previousEventHash: Schema.String,
   }),
-  author: Schema.Struct({
-    accountId: Schema.String,
-    publicKey: Schema.String,
-    signature: Schema.String,
-  }),
+  author: EventAuthor,
 });
 
 export type AcceptInvitationEvent = Schema.Schema.Type<typeof AcceptInvitationEvent>;

--- a/packages/hypergraph/test/space-events/accept-invitation.test.ts
+++ b/packages/hypergraph/test/space-events/accept-invitation.test.ts
@@ -46,16 +46,12 @@ it('should accept an invitation', async () => {
   expect(state3.id).toBeTypeOf('string');
   expect(state3.invitations).toEqual({});
   expect(state3.members).toEqual({
-    [author.signaturePublicKey]: {
+    [author.accountId]: {
       accountId: author.accountId,
-      signaturePublicKey: author.signaturePublicKey,
-      encryptionPublicKey: author.encryptionPublicKey,
       role: 'admin',
     },
-    [invitee.signaturePublicKey]: {
+    [invitee.accountId]: {
       accountId: invitee.accountId,
-      signaturePublicKey: invitee.signaturePublicKey,
-      encryptionPublicKey: invitee.encryptionPublicKey,
       role: 'member',
     },
   });

--- a/packages/hypergraph/test/space-events/create-invitation.test.ts
+++ b/packages/hypergraph/test/space-events/create-invitation.test.ts
@@ -50,15 +50,11 @@ it('should create an invitation', async () => {
   expect(state2.invitations).toEqual({
     [spaceEvent2.transaction.id]: {
       inviteeAccountId: invitee.accountId,
-      signaturePublicKey: '0x03bf5d2a1badf15387b08a007d1a9a13a9bfd6e1c56f681e251514d9ba10b57462',
-      encryptionPublicKey: 'encryption',
     },
   });
   expect(state2.members).toEqual({
-    [author.signaturePublicKey]: {
+    [author.accountId]: {
       accountId: author.accountId,
-      signaturePublicKey: author.signaturePublicKey,
-      encryptionPublicKey: author.encryptionPublicKey,
       role: 'admin',
     },
   });

--- a/packages/hypergraph/test/space-events/create-space.test.ts
+++ b/packages/hypergraph/test/space-events/create-space.test.ts
@@ -22,10 +22,8 @@ it('should create a space state', async () => {
   expect(state.id).toBeTypeOf('string');
   expect(state.invitations).toEqual({});
   expect(state.members).toEqual({
-    [author.signaturePublicKey]: {
+    [author.accountId]: {
       accountId: author.accountId,
-      signaturePublicKey: author.signaturePublicKey,
-      encryptionPublicKey: author.encryptionPublicKey,
       role: 'admin',
     },
   });

--- a/packages/hypergraph/test/space-events/delete-space.test.ts
+++ b/packages/hypergraph/test/space-events/delete-space.test.ts
@@ -36,10 +36,8 @@ it('should delete a space', async () => {
   expect(state.invitations).toEqual({});
   expect(state.members).toEqual({});
   expect(state.removedMembers).toEqual({
-    [author.signaturePublicKey]: {
+    [author.accountId]: {
       accountId: author.accountId,
-      signaturePublicKey: author.signaturePublicKey,
-      encryptionPublicKey: author.encryptionPublicKey,
       role: 'admin',
     },
   });


### PR DESCRIPTION
Based on this discussion https://github.com/graphprotocol/hypergraph/issues/70#issuecomment-2619049808 we want to use the `accountId` as primary identifier

One necessary follow up task to make it secure: https://github.com/graphprotocol/hypergraph/issues/129