### PR TITLE
fix server setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,16 @@ ENV DATABASE_URL="file:./dev.db"
 RUN \
   # TODO: This initalizes the database. But we should probably remove this later.
   pnpm --filter server prisma migrate reset --force && \
-  # Build the monorepo packages.
+  # Build the monorepo packages
   pnpm build && \
+  # Generate the prisma client
+  pnpm --filter server prisma generate && \
   # Build the server.
   pnpm --filter server build && \
   # Create an isolated deployment for the server.
   pnpm --filter server deploy --prod deployment --legacy && \
   # Move the runtime build artifacts into a separate directory.
-  mkdir -p deployment/out && mv deployment/dist deployment/prisma deployment/node_modules deployment/package.json deployment/out && \
-  # Generate the prisma client
-  (cd deployment/out && pnpx prisma generate)
+  mkdir -p deployment/out && mv deployment/dist deployment/prisma deployment/node_modules deployment/package.json deployment/out
 
 # Slim runtime image.
 FROM node:22-alpine AS server

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -2,8 +2,9 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "generated/client"
+  provider     = "prisma-client"
+  output       = "generated/client"
+  moduleFormat = "esm"
 }
 
 datasource db {


### PR DESCRIPTION
I upgrade Prisma and the node_modules based client generation was deprecated. I moved the generation to the `prisma` folder, but forgot the docker setup.

With the new client they simply generate TypeScript files with import statements. This means we can include it like any other code we have in our repository.