### PR TITLE
fix: inboxes and app keys

### DIFF
--- a/apps/connect/src/routes/authenticate.tsx
+++ b/apps/connect/src/routes/authenticate.tsx
@@ -407,8 +407,8 @@ function AuthenticateComponent() {
         appId: state.appInfo.appId,
         address: newAppIdentity.address,
         accountAddress,
-        signaturePublicKey: newAppIdentity.signaturePublicKey,
-        encryptionPublicKey: newAppIdentity.encryptionPublicKey,
+        signaturePublicKey: keys.signaturePublicKey,
+        encryptionPublicKey: keys.encryptionPublicKey,
         ciphertext,
         nonce,
         accountProof,
@@ -424,6 +424,8 @@ function AuthenticateComponent() {
         body: JSON.stringify(message),
       });
       const appIdentityResponse = await response.json();
+      // TODO: All apps are essentially using the same keys, we should change to using
+      // the newly created app identity keys, but that requires changing a lot of the verification logic in the server and HypergraphAppContext
       await encryptSpacesAndRedirect({
         accountAddress,
         appIdentity: {
@@ -432,8 +434,8 @@ function AuthenticateComponent() {
           accountAddress,
           encryptionPrivateKey: keys.encryptionPrivateKey,
           signaturePrivateKey: keys.signaturePrivateKey,
-          encryptionPublicKey: newAppIdentity.encryptionPublicKey,
-          signaturePublicKey: newAppIdentity.signaturePublicKey,
+          encryptionPublicKey: keys.encryptionPublicKey,
+          signaturePublicKey: keys.signaturePublicKey,
           sessionToken: appIdentityResponse.appIdentity.sessionToken,
           sessionTokenExpires: new Date(appIdentityResponse.appIdentity.sessionTokenExpires),
           permissionId,

--- a/packages/hypergraph-react/src/HypergraphAppContext.tsx
+++ b/packages/hypergraph-react/src/HypergraphAppContext.tsx
@@ -627,7 +627,7 @@ export function HypergraphAppProvider({
             }
             const inboxCreator = Inboxes.recoverAccountInboxCreatorKey(response.inbox);
             if (inboxCreator !== identity.signaturePublicKey) {
-              console.error('Invalid inbox creator', response.inbox);
+              console.error('Invalid inbox creator', response.inbox, inboxCreator, identity.signaturePublicKey);
               return;
             }
 
@@ -1019,7 +1019,7 @@ export function HypergraphAppProvider({
       }
       const message = await Inboxes.createSpaceInboxCreationMessage({
         author: {
-          accountAddress: identity.address,
+          accountAddress: identity.accountAddress,
           signaturePublicKey,
           encryptionPublicKey,
           signaturePrivateKey,
@@ -1118,7 +1118,7 @@ export function HypergraphAppProvider({
         throw new Error('Missing keys');
       }
       const message = await Inboxes.createAccountInboxCreationMessage({
-        accountAddress: identity.address,
+        accountAddress: identity.accountAddress,
         isPublic,
         authPolicy,
         encryptionPublicKey,

--- a/packages/hypergraph-react/src/hooks/useExternalSpaceInbox.ts
+++ b/packages/hypergraph-react/src/hooks/useExternalSpaceInbox.ts
@@ -51,8 +51,8 @@ export function useExternalSpaceInbox({
 
         let authorAccountAddress: string | null = null;
         let signaturePrivateKey: string | null = null;
-        if (identity?.address && inbox.authPolicy !== 'anonymous') {
-          authorAccountAddress = identity.address;
+        if (identity?.accountAddress && inbox.authPolicy !== 'anonymous') {
+          authorAccountAddress = identity.accountAddress;
           signaturePrivateKey = identity.signaturePrivateKey;
         } else if (inbox.authPolicy === 'requires_auth') {
           throw new Error('Cannot send message to a required auth inbox without an identity');

--- a/packages/hypergraph-react/src/hooks/useOwnSpaceInbox.ts
+++ b/packages/hypergraph-react/src/hooks/useOwnSpaceInbox.ts
@@ -104,8 +104,8 @@ export function useOwnSpaceInbox({
 
         let authorAccountAddress: string | null = null;
         let signaturePrivateKey: string | null = null;
-        if (identity?.address && ownInbox.authPolicy !== 'anonymous') {
-          authorAccountAddress = identity.address;
+        if (identity?.accountAddress && ownInbox.authPolicy !== 'anonymous') {
+          authorAccountAddress = identity.accountAddress;
           signaturePrivateKey = identity.signaturePrivateKey;
         } else if (ownInbox.authPolicy === 'requires_auth') {
           throw new Error('Cannot send message to a required auth inbox without an identity');


### PR DESCRIPTION
App identities aren't fully set up yet, so all apps are using the same keys for the moment.
This fixes inbox creation by ensuring the correct accountAddress is sent, and it also ensures the app's private and public keys match.
