### PR TITLE
chore: update create-hypergraph version

### DIFF
--- a/apps/create-hypergraph/CHANGELOG.md
+++ b/apps/create-hypergraph/CHANGELOG.md
@@ -1,20 +1,6 @@
 # create-hypergraph
 
-## 0.0.2
+## 0.1.0
 ### Patch Changes
 
-- 2d3814e: better check for access to template directory
-- 97894a1: test suite for Cli tool
-- f54e72a: create llms.txt for create-hypergraph usage
-- 4446ffe: resolve inputs from passed in options or prompts
-- f40426b: fix typo
-- ba47d53: rename package.json bin to create-hypergraph
-- 447cdb4: rename to create-hypergraph (drop app)
-- bd88912: handle sigint of user killing cli with a log line instead of error message
-- deee18d: add create-hypergraph-app tests to root workspace
-- 39beee4: fixes. updates from testing
-- 68a79db: rebase main. sort order import
-- 64d196d: buildout ability scaffold app, install deps, initialize git
-- 8ea798f: bump @types/node to latest
-- a004e4f: use prompts instead of options
-- 5a4c193: working on building create-hypergraph-app cli tool
+- Initial release

--- a/apps/create-hypergraph/package.json
+++ b/apps/create-hypergraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-hypergraph",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "CLI toolchain to scaffold a Hypergraph-enabled application with a given template.",
   "type": "module",
   "bin": {

--- a/apps/create-hypergraph/src/Cli.ts
+++ b/apps/create-hypergraph/src/Cli.ts
@@ -75,7 +75,7 @@ const createHypergraphApp = Command.make('create-hypergraph-app', {
 
 export const run = Command.run(createHypergraphApp, {
   name: 'create-hypergraph-app',
-  version: '0.0.3',
+  version: '0.1.0',
 });
 
 // ========================


### PR DESCRIPTION
The idea is as defined in semver with per 1.0.0 breaking changes can be a minor update and patches stay patches - see https://semver.org/#spec-item-4. This way we can do proper versioning from now on.

What do you think @cmwhited?