### PR TITLE
fix(#392 | move typesync api): update create-hypergraph templates to use Mapping exported from @graphprotocol/hypergraph

### DIFF
--- a/.changeset/metal-mangos-dig.md
+++ b/.changeset/metal-mangos-dig.md
@@ -1,0 +1,6 @@
+---
+"create-hypergraph": minor
+---
+
+Update templates to use Mapping exported from @graphprotocol/hypergraph package. Remove @graphprotocol/typesync dep from templates'
+  

--- a/apps/create-hypergraph/scripts/copy-template-dir.ts
+++ b/apps/create-hypergraph/scripts/copy-template-dir.ts
@@ -13,11 +13,8 @@ const workspaceDepsToReplace = {
   '@graphprotocol/hypergraph-react': {
     packageJson: 'packages/hypergraph-react/package.json',
   },
-  '@graphprotocol/typesync': {
-    packageJson: 'packages/typesync/package.json',
-  },
 } as const satisfies Record<
-  '@graphprotocol/hypergraph' | '@graphprotocol/hypergraph-react' | '@graphprotocol/typesync',
+  '@graphprotocol/hypergraph' | '@graphprotocol/hypergraph-react',
   { packageJson: `packages/${string}/package.json` }
 >;
 const ignore = new Set(['.git', 'node_modules', '.tanstack', 'dist', 'publish', 'build', '.next']);

--- a/apps/create-hypergraph/template-nextjs/app/mapping.ts
+++ b/apps/create-hypergraph/template-nextjs/app/mapping.ts
@@ -1,7 +1,7 @@
 import { Id } from '@graphprotocol/grc-20';
-import type { Mapping } from '@graphprotocol/typesync/Mapping';
+import type { Mapping } from '@graphprotocol/hypergraph';
 
-export const mapping: Mapping = {
+export const mapping: Mapping.Mapping = {
   Address: {
     typeIds: [Id.Id('5c6e72fb-8340-47c0-8281-8be159ecd495')],
     properties: {

--- a/apps/create-hypergraph/template-nextjs/package.json
+++ b/apps/create-hypergraph/template-nextjs/package.json
@@ -18,7 +18,6 @@
     "@graphprotocol/grc-20": "^0.21.6",
     "@graphprotocol/hypergraph": "workspace:*",
     "@graphprotocol/hypergraph-react": "workspace:*",
-    "@graphprotocol/typesync": "workspace:*",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/apps/create-hypergraph/template-vite-react/package.json
+++ b/apps/create-hypergraph/template-vite-react/package.json
@@ -14,7 +14,6 @@
     "@graphprotocol/grc-20": "^0.21.6",
     "@graphprotocol/hypergraph": "workspace:*",
     "@graphprotocol/hypergraph-react": "workspace:*",
-    "@graphprotocol/typesync": "workspace:*",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/apps/create-hypergraph/template-vite-react/src/mapping.ts
+++ b/apps/create-hypergraph/template-vite-react/src/mapping.ts
@@ -1,7 +1,7 @@
 import { Id } from '@graphprotocol/grc-20';
-import type { Mapping } from '@graphprotocol/typesync/Mapping';
+import type { Mapping } from '@graphprotocol/hypergraph';
 
-export const mapping: Mapping = {
+export const mapping: Mapping.Mapping = {
   Address: {
     typeIds: [Id.Id('5c6e72fb-8340-47c0-8281-8be159ecd495')],
     properties: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,8 @@ importers:
         version: 4.20.3
     publishDirectory: dist
 
+  apps/create-hypergraph/dist: {}
+
   apps/create-hypergraph/template-nextjs:
     dependencies:
       '@graphprotocol/grc-20':
@@ -184,9 +186,6 @@ importers:
       '@graphprotocol/hypergraph-react':
         specifier: workspace:*
         version: link:../../../packages/hypergraph-react/publish
-      '@graphprotocol/typesync':
-        specifier: workspace:*
-        version: link:../../../packages/typesync/publish
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -266,9 +265,6 @@ importers:
       '@graphprotocol/hypergraph-react':
         specifier: workspace:*
         version: link:../../../packages/hypergraph-react/publish
-      '@graphprotocol/typesync':
-        specifier: workspace:*
-        version: link:../../../packages/typesync/publish
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
# Description

Followup to #393. Updated the create-hypergraph/template-* to use the `Mapping` type exported from`@graphprotocol/hypergraph` and removed `@graphprotocol/typesync` as a dep.