### PR TITLE
proposal: hook for publishing public data

### DIFF
--- a/packages/hypergraph-react/src/hooks/usePublishToSpace.ts
+++ b/packages/hypergraph-react/src/hooks/usePublishToSpace.ts
@@ -1,0 +1,28 @@
+import type { Entity } from '@graphprotocol/hypergraph';
+import { useMutation } from '@tanstack/react-query';
+import { useHypergraphApp } from '../HypergraphAppContext.js';
+import { preparePublish } from '../prepare-publish.js';
+import { publishOps } from '../publish-ops.js';
+
+export function usePublishToPublicSpace<S extends Entity.AnyNoContext>(spaceId: string) {
+  const { getSmartSessionClient } = useHypergraphApp();
+
+  return useMutation({
+    mutationFn: async (entity: Entity.Entity<S>) => {
+      const { ops } = await preparePublish({
+        entity,
+        publicSpace: spaceId,
+      });
+      const smartSessionClient = await getSmartSessionClient();
+      if (!smartSessionClient) {
+        throw new Error('Missing smartSessionClient');
+      }
+      return await publishOps({
+        ops,
+        space: spaceId,
+        name: 'Published entity',
+        walletClient: smartSessionClient,
+      });
+    },
+  });
+}

--- a/packages/hypergraph-react/src/index.ts
+++ b/packages/hypergraph-react/src/index.ts
@@ -22,6 +22,7 @@ export { useExternalSpaceInbox } from './hooks/useExternalSpaceInbox.js';
 export { useOwnAccountInbox } from './hooks/useOwnAccountInbox.js';
 export { useOwnSpaceInbox } from './hooks/useOwnSpaceInbox.js';
 export { usePublicAccountInboxes } from './hooks/usePublicAccountInboxes.js';
+export { usePublishToPublicSpace } from './hooks/usePublishToSpace.js';
 export { generateDeleteOps as _generateDeleteOps } from './internal/generate-delete-ops.js';
 export { useCreateEntityPublic as _useCreateEntityPublic } from './internal/use-create-entity-public.js';
 export { useDeleteEntityPublic as _useDeleteEntityPublic } from './internal/use-delete-entity-public.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,81 +720,6 @@ importers:
         version: 7.0.4(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.1)(tsx@4.20.3)(yaml@2.7.0)
     publishDirectory: dist
 
-  apps/typesync/dist:
-    dependencies:
-      '@graphprotocol/grc-20':
-        specifier: ^0.21.6
-        version: 0.21.6(bufferutil@4.0.9)(graphql@16.11.0)(ox@0.6.7(typescript@5.8.3)(zod@3.25.51))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.51)
-      '@graphprotocol/typesync':
-        specifier: ^0.0.3
-        version: 0.0.3(bufferutil@4.0.9)(graphql@16.11.0)(ox@0.6.7(typescript@5.8.3)(zod@3.25.51))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.51)
-      '@graphql-typed-document-node/core':
-        specifier: ^3.2.0
-        version: 3.2.0(graphql@16.11.0)
-      '@headlessui/react':
-        specifier: ^2.2.4
-        version: 2.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@heroicons/react':
-        specifier: ^2.2.0
-        version: 2.2.0(react@19.1.0)
-      '@phosphor-icons/react':
-        specifier: ^2.1.10
-        version: 2.1.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-tabs':
-        specifier: ^1.1.12
-        version: 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@tailwindcss/vite':
-        specifier: ^4.1.11
-        version: 4.1.11(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.1)(tsx@4.20.3)(yaml@2.7.0))
-      '@tanstack/react-form':
-        specifier: ^1.14.1
-        version: 1.14.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@tanstack/react-query':
-        specifier: ^5.83.0
-        version: 5.83.0(react@19.1.0)
-      '@tanstack/react-query-devtools':
-        specifier: ^5.83.0
-        version: 5.83.0(@tanstack/react-query@5.83.0(react@19.1.0))(react@19.1.0)
-      '@tanstack/react-router':
-        specifier: ^1.129.5
-        version: 1.129.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@tanstack/react-router-devtools':
-        specifier: ^1.129.5
-        version: 1.129.5(@tanstack/react-router@1.129.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.129.6)(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(tiny-invariant@1.3.3)
-      better-sqlite3:
-        specifier: ^12.2.0
-        version: 12.2.0
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
-      effect:
-        specifier: ^3.17.3
-        version: 3.17.3
-      graphql:
-        specifier: ^16.11.0
-        version: 16.11.0
-      graphql-request:
-        specifier: ^7.2.0
-        version: 7.2.0(graphql@16.11.0)
-      jotai:
-        specifier: ^2.12.5
-        version: 2.12.5(@types/react@19.1.8)(react@19.1.0)
-      open:
-        specifier: ^10.2.0
-        version: 10.2.0
-      react:
-        specifier: ^19.1.0
-        version: 19.1.0
-      react-dom:
-        specifier: ^19.1.0
-        version: 19.1.0(react@19.1.0)
-      shiki:
-        specifier: ^3.8.0
-        version: 3.8.0
-      tailwindcss:
-        specifier: ^4.1.11
-        version: 4.1.11
-
   docs:
     dependencies:
       '@docusaurus/core':
@@ -7941,9 +7866,6 @@ packages:
 
   effect@3.17.1:
     resolution: {integrity: sha512-t917ks10FGNf7MpwOxHUg6vo42p0XsdMHuBMVpy4NttPu5gIv8/ah5MgbHLVQJ2kmDvZfQUT1/xyCa1IR09u2Q==}
-
-  effect@3.17.3:
-    resolution: {integrity: sha512-FbFMr6xBXPII5Od8QJnkHz+2GTmQgq+8NPQev6C2k9cf1lcUjQ4vpw1kjbMc2X0UkjIkIWe0EtNK2RV6bl34UQ==}
 
   electron-to-chromium@1.5.152:
     resolution: {integrity: sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==}
@@ -23167,11 +23089,6 @@ snapshots:
       fast-check: 3.23.2
 
   effect@3.17.1:
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      fast-check: 3.23.2
-
-  effect@3.17.3:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2


### PR DESCRIPTION
Currently to publish private data to a public space you need to create a hand-rolled function combining multiple pieces of functionality from Hypergraph. It would be simpler if all of this logic was wrapped in a hook which exposed the function for publishing.

Another benefit is that we can expose all the state machine states to the user during publishing so they can handle it in their UI. This was my main motivation as publishing data in the Vite template has no feedback as to what's happening.

### Current implementation
```tsx
import {
  preparePublish,
  publishOps,
  useHypergraphApp,
} from '@graphprotocol/hypergraph-react';

function Example() {
  const { getSmartSessionClient } = useHypergraphApp();

 const publishToPublicSpace = async (address: Address) => {
    if (!selectedSpace) {
      alert('No space selected');
      return;
    }
    try {
      const { ops } = await preparePublish({ entity: address, publicSpace: selectedSpace });
      const smartSessionClient = await getSmartSessionClient();
      if (!smartSessionClient) {
        throw new Error('Missing smartSessionClient');
      }
      const publishResult = await publishOps({
        ops,
        space: selectedSpace,
        name: 'Publish Address',
        walletClient: smartSessionClient,
      });
      console.log(publishResult, ops);
      alert('Address published to public space');
    } catch (error) {
      console.error(error);
      alert('Error publishing address to public space');
    }
  };
  
    return <button onClick={() => publishToPublicSpace(address)}>Publish</button>
}
```

### Hook-based implementation
```tsx

import { usePublishToPublicSpace } from '@graphprotocol/hypergraph-react';
function Example() {
  const {mutateAsync, isPending, isError} = usePublishToPublicSpace("5")

  return <button onClick={() => mutateAsync(address)}>Publish</button>
}


```