### PR TITLE
export Id from grc-20

### DIFF
--- a/.changeset/fair-weeks-double.md
+++ b/.changeset/fair-weeks-double.md
@@ -1,0 +1,6 @@
+---
+"@graphprotocol/hypergraph": patch
+---
+
+export Id (re-exported from grc-20)
+  

--- a/packages/hypergraph/src/index.ts
+++ b/packages/hypergraph/src/index.ts
@@ -1,3 +1,4 @@
+export { Id } from '@graphprotocol/grc-20';
 export * as Connect from './connect/index.js';
 export * as Entity from './entity/index.js';
 export * as Identity from './identity/index.js';


### PR DESCRIPTION
The idea is if we export the ID directly from hypergraph the templates won't need grc-20 dependency at all