### PR TITLE
fix(usePublishToPublicSpace): update entity type def to be instance of type

### DIFF
--- a/.changeset/empty-rivers-talk.md
+++ b/.changeset/empty-rivers-talk.md
@@ -1,0 +1,6 @@
+---
+"@graphprotocol/hypergraph-react": patch
+---
+
+Update variable types of usePublishToPublicSpace function to accept and instance of an Entity and not the Entity type
+  

--- a/packages/hypergraph-react/src/hooks/usePublishToSpace.ts
+++ b/packages/hypergraph-react/src/hooks/usePublishToSpace.ts
@@ -6,22 +6,24 @@ import { publishOps } from '../publish-ops.js';
 import type { OmitStrict } from '../types.js';
 
 type Variables<S extends Entity.AnyNoContext> = {
-  entity: S;
+  entity: Entity.Entity<S>;
   spaceId: string;
 };
 
-type UsePublishToSpaceOptions = OmitStrict<
-  UseMutationOptions<Awaited<ReturnType<typeof publishOps>>, Error, Variables<Entity.AnyNoContext>, unknown>,
+type UsePublishToSpaceOptions<S extends Entity.AnyNoContext> = OmitStrict<
+  UseMutationOptions<Awaited<ReturnType<typeof publishOps>>, Error, Variables<S>, unknown>,
   'mutationFn' | 'mutationKey'
 >;
 
-export function usePublishToPublicSpace(options: UsePublishToSpaceOptions = {}) {
+export function usePublishToPublicSpace<const S extends Entity.AnyNoContext>(
+  options: UsePublishToSpaceOptions<S> = {},
+) {
   const { getSmartSessionClient } = useHypergraphApp();
 
   return useMutation({
     ...options,
     mutationFn: async ({ entity, spaceId }) => {
-      const { ops } = await preparePublish({
+      const { ops } = await preparePublish<S>({
         entity,
         publicSpace: spaceId,
       });


### PR DESCRIPTION
# Description

Sets the entity variable to be an instance of type `S` and not type `S` itself.

[See more](https://graphprotocol.slack.com/archives/C069PB8PCPN/p1754596448222099)