### PR TITLE
feat(core): tighten filter types per (breaking)

### DIFF
--- a/packages/hypergraph/src/entity/types.ts
+++ b/packages/hypergraph/src/entity/types.ts
@@ -55,8 +55,6 @@ export type EntityNumberFilter = {
   is?: number;
   greaterThan?: number;
   lessThan?: number;
-  not?: EntityNumberFilter;
-  or?: EntityNumberFilter[];
 };
 
 export type EntityStringFilter = {
@@ -64,8 +62,6 @@ export type EntityStringFilter = {
   startsWith?: string;
   endsWith?: string;
   contains?: string;
-  not?: EntityStringFilter;
-  or?: EntityStringFilter[];
 };
 
 export type CrossFieldFilter<T> = {
@@ -77,8 +73,6 @@ export type CrossFieldFilter<T> = {
 
 export type EntityFieldFilter<T> = {
   is?: T;
-  not?: EntityFieldFilter<T>;
-  or?: Array<EntityFieldFilter<T>>;
 } & (T extends boolean
   ? {
       is?: boolean;

--- a/packages/hypergraph/test/entity/findMany.test.ts
+++ b/packages/hypergraph/test/entity/findMany.test.ts
@@ -193,7 +193,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          name: { not: { is: 'John' } },
+          not: { name: { is: 'John' } },
         },
         undefined,
       );
@@ -212,7 +212,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          age: { not: { is: 30 } },
+          not: { age: { is: 30 } },
         },
         undefined,
       );
@@ -233,7 +233,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          name: { or: [{ is: 'John' }, { is: 'Jane' }] },
+          or: [{ name: { is: 'John' } }, { name: { is: 'Jane' } }],
         },
         undefined,
       );
@@ -252,7 +252,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          age: { or: [{ is: 25 }, { is: 40 }] },
+          or: [{ age: { is: 25 } }, { age: { is: 40 } }],
         },
         undefined,
       );
@@ -273,7 +273,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          name: { not: { or: [{ is: 'John' }, { is: 'Jane' }] } },
+          not: { or: [{ name: { is: 'John' } }, { name: { is: 'Jane' } }] },
         },
         undefined,
       );
@@ -292,7 +292,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          name: { not: { or: [{ is: 'John' }, { is: 'Jane' }] } },
+          not: { or: [{ name: { is: 'John' } }, { name: { is: 'Jane' } }] },
         },
         undefined,
       );
@@ -384,8 +384,7 @@ describe('findMany with filters', () => {
         handle,
         Person,
         {
-          name: { not: { startsWith: 'J' } },
-          age: { not: { greaterThan: 35 } },
+          not: { or: [{ name: { startsWith: 'J' } }, { age: { greaterThan: 35 } }] },
         },
         undefined,
       );


### PR DESCRIPTION
Disallowing field-level logical operators in filters; only allow them at the root cross-field level. Implements #442.

changes I did :-

removed not and or from `EntityFieldFilter<T>`. 
Root `CrossFieldFilter<T>` continues to support not/or.
Runtime : reject not/or/and if provided inside a single field filter.
Evaluator: correctly handles nested or and not at the cross-field level with AND semantics for regular fields.
Tests: updated all filter tests to use root-level not/or and added coverage for combined/nested cases.
Lint: cleaned up type-safe access and formatting.

Examples :- 

Before:
{ name: { not: { is: "Jane" } } }
{ age: { or: [{ is: 25 }, { is: 40 }] } }

After:
{ not: { name: { is: "Jane" } } }
{ or: [{ age: { is: 25 } }, { age: { is: 40 } }] }

Notes
No server/docs/deploy changes required.
No public GraphQL filter changes in this PR; this strictly tightens local filtering semantics.

Issue
Closes #442

Checklist
[x] Tests added/updated
[x] Types updated
[x] Lint/typecheck/build pass

