### PR TITLE
feat(#465 | docs): add public data query examples using useQuery

### DIFF
--- a/docs/docs/query-public-data.md
+++ b/docs/docs/query-public-data.md
@@ -69,7 +69,7 @@ The Geo testnet contains public data that you can query immediately without any 
 - **No authentication required** for public data queries.
 - All examples below use the Geo testnet space ID: `b2565802-3118-47be-91f2-e59170735bac`
 
-Each section below includes the relevant schema definition followed by a working query example.
+Each section below includes the relevant `schema.ts`, `mapping.ts`, and a query example.
 
 ### Projects Example
 
@@ -86,6 +86,25 @@ export class Project extends Entity.Class<Project>("Project")({
 }) {}
 ```
 
+**Mapping Definition:**
+
+```typescript
+// app/mapping.ts
+import type { Mapping } from '@graphprotocol/hypergraph';
+import { Id } from '@graphprotocol/hypergraph';
+
+export const mapping: Mapping.Mapping = {
+  Project: {
+    typeIds: [Id('484a18c5-030a-499c-b0f2-ef588ff16d50')],
+    properties: {
+      name: Id('a126ca53-0c8e-48d5-b888-82c734c38935'),
+      description: Id('9b1f76ff-9711-404c-861e-59dc3fa7d037'),
+      xUrl: Id('0d625978-4b3c-4b57-a86f-de45c997c73c'),
+    },
+  },
+};
+```
+
 **Query Example:**
 
 ```tsx
@@ -95,10 +114,8 @@ import { useState } from "react";
 import { useQuery } from "@graphprotocol/hypergraph-react";
 import { Project } from "../schema";
 
-const LIMIT = 20;
-
 export default function ProjectsExample() {
-  const [limit, setLimit] = useState(LIMIT);
+  const [limit, setLimit] = useState(40);
   const {
     data: projects,
     isPending,
@@ -114,32 +131,28 @@ export default function ProjectsExample() {
 
   return (
     <div>
-      <h2 className="text-xl font-bold mb-4">Projects</h2>
+      <h2>Projects</h2>
       <ul>
         {projects.map((project) => (
-          <li key={project.id} className="mb-2 p-2 border rounded">
-            <h3 className="font-bold">{project.name}</h3>
+          <li key={project.id}>
+            <h3>
+              Name: {project.name} 
+            </h3>
             {project.description && (
-              <p className="text-gray-600">{project.description}</p>
+              <p>Description: {project.description}</p>
             )}
-            {project.xUrl && (
-              <a
-                href={project.xUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-500"
-              >
-                View on X
-              </a>
-            )}
+             {project.xUrl && (
+                <a href={project.xUrl} target="_blank" rel="noopener noreferrer">
+                 View on X
+                </a>
+              )}
           </li>
         ))}
       </ul>
       {projects.length >= limit && (
-        <div className="flex justify-center mt-6">
+        <div>
           <button
-            onClick={() => setLimit((n) => n + LIMIT)}
-            className="px-6 py-2 bg-blue-600 text-white rounded"
+            onClick={() => setLimit((n) => n + 40)}
           >
             Load more
           </button>
@@ -166,6 +179,26 @@ export class Dapp extends Entity.Class<Dapp>("Dapp")({
 }) {}
 ```
 
+**Mapping Definition:**
+
+```typescript
+// app/mapping.ts
+import type { Mapping } from '@graphprotocol/hypergraph';
+import { Id } from '@graphprotocol/hypergraph';
+
+export const mapping: Mapping.Mapping = {
+  Dapp: {
+    typeIds: [Id('8ca136d0-698a-4bbf-a76b-8e2741b2dc8c')],
+    properties: {
+      name: Id('a126ca53-0c8e-48d5-b888-82c734c38935'),
+      description: Id('9b1f76ff-9711-404c-861e-59dc3fa7d037'),
+      xUrl: Id('0d625978-4b3c-4b57-a86f-de45c997c73c'),
+      githubUrl: Id('9eedefa8-60ae-4ac1-9a04-805054a4b094'),
+    },
+  },
+};
+```
+
 **Query Example:**
 
 ```tsx
@@ -175,10 +208,8 @@ import { useState } from "react";
 import { useQuery } from "@graphprotocol/hypergraph-react";
 import { Dapp } from "../schema";
 
-const LIMIT = 20;
-
 export default function DappsExample() {
-  const [limit, setLimit] = useState(LIMIT);
+  const [limit, setLimit] = useState(40);
   const {
     data: dapps,
     isPending,
@@ -194,32 +225,27 @@ export default function DappsExample() {
 
   return (
     <div>
-      <h2 className="text-xl font-bold mb-4">dApps</h2>
+      <h2>dApps</h2>
       <ul>
         {dapps.map((dapp) => (
-          <li key={dapp.id} className="mb-2 p-2 border rounded">
-            <h3 className="font-bold">{dapp.name}</h3>
+          <li key={dapp.id}>
+            <h3>Name: {dapp.name}</h3>
             {dapp.description && (
-              <p className="text-gray-600">{dapp.description}</p>
+              <p>Description: {dapp.description}</p>
             )}
-            <div className="flex gap-2 mt-2">
+            <div>
               {dapp.xUrl && (
                 <a
                   href={dapp.xUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-500"
                 >
                   View on X
                 </a>
               )}
               {dapp.githubUrl && (
-                <a
-                  href={dapp.githubUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-500"
-                >
+                <a href={dapp.githubUrl} target="_blank" rel="noopener noreferrer">
+                  {' '}
                   GitHub
                 </a>
               )}
@@ -228,10 +254,9 @@ export default function DappsExample() {
         ))}
       </ul>
       {dapps.length >= limit && (
-        <div className="flex justify-center mt-6">
+        <div>
           <button
-            onClick={() => setLimit((n) => n + LIMIT)}
-            className="px-6 py-2 bg-blue-600 text-white rounded"
+            onClick={() => setLimit((n) => n + 40)}
           >
             Load more
           </button>
@@ -268,6 +293,37 @@ export class InvestmentRound extends Entity.Class<InvestmentRound>(
 }) {}
 ```
 
+**Mapping Definition:**
+
+```typescript
+// app/mapping.ts
+import type { Mapping } from '@graphprotocol/hypergraph';
+import { Id } from '@graphprotocol/hypergraph';
+
+export const mapping: Mapping.Mapping = {
+  Investor: {
+    typeIds: [Id('331aea18-973c-4adc-8f53-614f598d262d')],
+    properties: { name: Id('a126ca53-0c8e-48d5-b888-82c734c38935') },
+  },
+  FundingStage: {
+    typeIds: [Id('8d35d217-3fa1-4686-b74f-fcb3e9438067')],
+    properties: { name: Id('a126ca53-0c8e-48d5-b888-82c734c38935') },
+  },
+  InvestmentRound: {
+    typeIds: [Id('8f03f4c9-59e4-44a8-a625-c0a40b1ff330')],
+    properties: {
+      name: Id('a126ca53-0c8e-48d5-b888-82c734c38935'),
+      raisedAmount: Id('16781706-dd9c-48bf-913e-cdf18b56034f'),
+    },
+    relations: {
+      investors: Id('9b8a610a-fa35-486e-a479-e253dbdabb4f'),
+      fundingStages: Id('e278c3d4-78b9-4222-b272-5a39a8556bd2'),
+      raisedBy: Id('b4878d1a-0609-488d-b8a6-e19862d6b62f'),
+    },
+  },
+};
+```
+
 **Query Example:**
 
 ```tsx
@@ -277,10 +333,8 @@ import { useState } from "react";
 import { useQuery } from "@graphprotocol/hypergraph-react";
 import { InvestmentRound } from "../schema";
 
-const LIMIT = 20;
-
 export default function InvestmentRoundsExample() {
-  const [limit, setLimit] = useState(LIMIT);
+  const [limit, setLimit] = useState(40);
   const {
     data: investmentRounds,
     isPending,
@@ -300,29 +354,29 @@ export default function InvestmentRoundsExample() {
 
   return (
     <div>
-      <h2 className="text-xl font-bold mb-4">Investment Rounds</h2>
+      <h2>Investment Rounds</h2>
       <ul>
         {investmentRounds.map((round) => (
-          <li key={round.id} className="mb-4 p-4 border rounded">
-            <h3 className="font-bold text-lg">{round.name}</h3>
+          <li key={round.id}>
+            <h3>Name: {round.name}</h3>
 
             {round.raisedAmount && (
-              <p className="text-green-600 font-semibold">
+              <p>
                 Amount Raised: ${round.raisedAmount?.toLocaleString()}
               </p>
             )}
 
             {round.fundingStages.length > 0 && (
-              <p className="text-gray-600">
+              <p>
                 Stage:{" "}
                 {round.fundingStages.map((stage) => stage.name).join(", ")}
               </p>
             )}
 
             {round.investors.length > 0 && (
-              <div className="mt-2">
-                <strong>Investors:</strong>
-                <ul className="ml-4 list-disc">
+              <div>
+                <p>Investors:</p>
+                <ul>
                   {round.investors.map((investor) => (
                     <li key={investor.id}>{investor.name}</li>
                   ))}
@@ -333,10 +387,9 @@ export default function InvestmentRoundsExample() {
         ))}
       </ul>
       {investmentRounds.length >= limit && (
-        <div className="flex justify-center mt-6">
+        <div>
           <button
-            onClick={() => setLimit((n) => n + LIMIT)}
-            className="px-6 py-2 bg-blue-600 text-white rounded"
+            onClick={() => setLimit((n) => n + 40)}
           >
             Load more
           </button>
@@ -362,6 +415,26 @@ export class Asset extends Entity.Class<Asset>("Asset")({
 }) {}
 ```
 
+**Mapping Definition:**
+
+```typescript
+// app/mapping.ts
+import type { Mapping } from '@graphprotocol/hypergraph';
+import { Id } from '@graphprotocol/hypergraph';
+
+export const mapping: Mapping.Mapping = {
+  Asset: {
+    typeIds: [Id('f8780a80-c238-4a2a-96cb-567d88b1aa63')],
+    properties: {
+      name: Id('a126ca53-0c8e-48d5-b888-82c734c38935'),
+      symbol: Id('ace1e96c-9b83-47b4-bd33-1d302ec0a0f5'),
+      blockchainAddress: Id('56b5944f-f059-48d1-b0fa-34abe84219da'),
+    },
+  },
+};
+
+```
+
 **Query Example:**
 
 ```tsx
@@ -371,10 +444,8 @@ import { useState } from "react";
 import { useQuery } from "@graphprotocol/hypergraph-react";
 import { Asset } from "../schema";
 
-const LIMIT = 20;
-
 export default function AssetMarketExample() {
-  const [limit, setLimit] = useState(LIMIT);
+  const [limit, setLimit] = useState(40);
   const {
     data: assets,
     isPending,
@@ -390,16 +461,16 @@ export default function AssetMarketExample() {
 
   return (
     <div>
-      <h2 className="text-xl font-bold mb-4">Asset Market</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <h2>Asset Market</h2>
+      <div>
         {assets.map((asset) => (
-          <div key={asset.id} className="p-4 border rounded-lg">
-            <h3 className="font-bold">{asset.name}</h3>
+          <div key={asset.id}>
+            <h3>Name: {asset.name}</h3>
 
-            {asset.symbol && <p className="text-gray-600">{asset.symbol}</p>}
+            {asset.symbol && <p>Symbol: {asset.symbol}</p>}
 
             {asset.blockchainAddress && (
-              <p className="text-xs text-gray-500 mt-2 font-mono break-all">
+              <p>
                 Address: {asset.blockchainAddress}
               </p>
             )}
@@ -407,10 +478,9 @@ export default function AssetMarketExample() {
         ))}
       </div>
       {assets.length >= limit && (
-        <div className="flex justify-center mt-6">
+        <div>
           <button
-            onClick={() => setLimit((n) => n + LIMIT)}
-            className="px-6 py-2 bg-blue-600 text-white rounded"
+            onClick={() => setLimit((n) => n + 40)}
           >
             Load more
           </button>


### PR DESCRIPTION
Closes #465 

- [x] Page contains a clearly marked “Querying Public Data from Geo Testnet using useQuery” section.
- [x] Each of the four types has one verified, runnable useQuery example that returns data.
- [x] Code is copy-paste ready for hackathon participants.
- [x] Endpoint and “no auth required” note are documented.
<img width="1470" height="814" alt="Screenshot 2025-08-12 at 5 23 02 PM" src="https://github.com/user-attachments/assets/b01421cb-34ea-4433-ba19-5aff82dd06e8" />
<img width="1470" height="814" alt="Screenshot 2025-08-12 at 5 24 16 PM" src="https://github.com/user-attachments/assets/8fd8ae3d-1676-4a80-a94a-0ba415edda98" />
<img width="1470" height="814" alt="Screenshot 2025-08-12 at 5 26 15 PM" src="https://github.com/user-attachments/assets/167d55f5-d001-4edb-b16a-c0064f0170f6" />
<img width="1470" height="814" alt="Screenshot 2025-08-12 at 5 27 36 PM" src="https://github.com/user-attachments/assets/aa2171f0-1ef8-4022-ae7e-f66f48953fe3" />
