### PR TITLE
feat(filters): add Date & Point “is” for private and public query 

### DIFF
--- a/packages/hypergraph-react/src/internal/translate-filter-to-graphql.test.ts
+++ b/packages/hypergraph-react/src/internal/translate-filter-to-graphql.test.ts
@@ -346,3 +346,53 @@ describe('translateFilterToGraphql with complex nested filters', () => {
     });
   });
 });
+
+describe('translateFilterToGraphql date/point filters', () => {
+  class Event extends Entity.Class<Event>('Event')({
+    name: Type.String,
+    when: Type.Date,
+    location: Type.Point,
+  }) {}
+
+  const eventMapping: Mapping.Mapping = {
+    Event: {
+      typeIds: [Id('a288444f-06a3-4037-9ace-66fe325864d0')],
+      properties: {
+        name: Id('a126ca53-0c8e-48d5-b888-82c734c38935'),
+        when: Id('9b53690f-ea6d-4bd8-b4d3-9ea01e7f837f'),
+        location: Id('45e707a5-4364-42fb-bb0b-927a5a8bc061'),
+      },
+    },
+  };
+
+  it('should translate Date `is` filter correctly', () => {
+    const dt = new Date('2024-01-01T00:00:00Z');
+    const filter: Entity.EntityFilter<Event> = { when: { is: dt } };
+
+    const result = translateFilterToGraphql(filter, Event, eventMapping);
+
+    expect(result).toEqual({
+      values: {
+        some: {
+          propertyId: { is: '9b53690f-ea6d-4bd8-b4d3-9ea01e7f837f' },
+          time: { is: Graph.serializeDate(dt) },
+        },
+      },
+    });
+  });
+
+  it('should translate Point `is` filter correctly', () => {
+    const filter: Entity.EntityFilter<Event> = { location: { is: [1, 2] as const } };
+
+    const result = translateFilterToGraphql(filter, Event, eventMapping);
+
+    expect(result).toEqual({
+      values: {
+        some: {
+          propertyId: { is: '45e707a5-4364-42fb-bb0b-927a5a8bc061' },
+          point: { is: Graph.serializePoint([1, 2]) },
+        },
+      },
+    });
+  });
+});

--- a/packages/hypergraph-react/src/internal/translate-filter-to-graphql.ts
+++ b/packages/hypergraph-react/src/internal/translate-filter-to-graphql.ts
@@ -17,6 +17,14 @@ type GraphqlFilterEntry =
           | {
               propertyId: { is: string };
               number: { is: string } | { greaterThan: string } | { lessThan: string };
+            }
+          | {
+              propertyId: {is: string};
+              time: {is: string};
+            }
+          | {
+              propertyId: {is: string};
+              point: {is: string};
             };
       };
     }
@@ -124,6 +132,28 @@ export function translateFilterToGraphql<S extends Entity.AnyNoContext>(
             },
           },
         });
+      }
+
+      if (TypeUtils.isDateOrOptionalDateType(type.fields[fieldName]) && fieldFilter.is instanceof Date) {
+        graphqlFilter.push({
+          values:{
+            some:{
+              propertyId:{is:propertyId},
+              time: {is: Graph.serializeDate(fieldFilter.is)},
+            },
+          },
+        });
+      }
+
+      if(TypeUtils.isPointOrOptionalPointType(type.fields[fieldName]) && Array.isArray(fieldFilter.is)&& fieldFilter.is.length === 2){
+        graphqlFilter.push({
+          values:{
+            some:{
+              propertyId: {is:propertyId},
+              point: { is: Graph.serializePoint([...(fieldFilter.is as ReadonlyArray<number>)]) },
+            }
+          }
+        })
       }
     }
   }

--- a/packages/hypergraph-react/src/internal/translate-filter-to-graphql.ts
+++ b/packages/hypergraph-react/src/internal/translate-filter-to-graphql.ts
@@ -19,12 +19,12 @@ type GraphqlFilterEntry =
               number: { is: string } | { greaterThan: string } | { lessThan: string };
             }
           | {
-              propertyId: {is: string};
-              time: {is: string};
+              propertyId: { is: string };
+              time: { is: string };
             }
           | {
-              propertyId: {is: string};
-              point: {is: string};
+              propertyId: { is: string };
+              point: { is: string };
             };
       };
     }
@@ -136,24 +136,28 @@ export function translateFilterToGraphql<S extends Entity.AnyNoContext>(
 
       if (TypeUtils.isDateOrOptionalDateType(type.fields[fieldName]) && fieldFilter.is instanceof Date) {
         graphqlFilter.push({
-          values:{
-            some:{
-              propertyId:{is:propertyId},
-              time: {is: Graph.serializeDate(fieldFilter.is)},
+          values: {
+            some: {
+              propertyId: { is: propertyId },
+              time: { is: Graph.serializeDate(fieldFilter.is) },
             },
           },
         });
       }
 
-      if(TypeUtils.isPointOrOptionalPointType(type.fields[fieldName]) && Array.isArray(fieldFilter.is)&& fieldFilter.is.length === 2){
+      if (
+        TypeUtils.isPointOrOptionalPointType(type.fields[fieldName]) &&
+        Array.isArray(fieldFilter.is) &&
+        fieldFilter.is.length === 2
+      ) {
         graphqlFilter.push({
-          values:{
-            some:{
-              propertyId: {is:propertyId},
+          values: {
+            some: {
+              propertyId: { is: propertyId },
               point: { is: Graph.serializePoint([...(fieldFilter.is as ReadonlyArray<number>)]) },
-            }
-          }
-        })
+            },
+          },
+        });
       }
     }
   }

--- a/packages/hypergraph/src/entity/findMany.ts
+++ b/packages/hypergraph/src/entity/findMany.ts
@@ -308,14 +308,14 @@ export function findMany<const S extends AnyNoContext>(
       }
     }
     if (fieldValue instanceof Date && 'is' in fieldFilter) {
-      const target = (fieldFilter as {is? : Date}).is;
-      if (target instanceof Date){
+      const target = (fieldFilter as { is?: Date }).is;
+      if (target instanceof Date) {
         return fieldValue.getTime() === target.getTime();
       }
     }
 
-    if(Array.isArray(fieldValue) && fieldValue.length === 2 && 'is' in fieldFilter){
-      const target = (fieldFilter as {is? : ReadonlyArray<number>}).is;
+    if (Array.isArray(fieldValue) && fieldValue.length === 2 && 'is' in fieldFilter) {
+      const target = (fieldFilter as { is?: ReadonlyArray<number> }).is;
       if (Array.isArray(target) && target.length === 2) {
         return fieldValue[0] === target[0] && fieldValue[1] === target[1];
       }

--- a/packages/hypergraph/src/entity/findMany.ts
+++ b/packages/hypergraph/src/entity/findMany.ts
@@ -307,7 +307,19 @@ export function findMany<const S extends AnyNoContext>(
         }
       }
     }
+    if (fieldValue instanceof Date && 'is' in fieldFilter) {
+      const target = (fieldFilter as {is? : Date}).is;
+      if (target instanceof Date){
+        return fieldValue.getTime() === target.getTime();
+      }
+    }
 
+    if(Array.isArray(fieldValue) && fieldValue.length === 2 && 'is' in fieldFilter){
+      const target = (fieldFilter as {is? : ReadonlyArray<number>}).is;
+      if (Array.isArray(target) && target.length === 2) {
+        return fieldValue[0] === target[0] && fieldValue[1] === target[1];
+      }
+    }
     return true;
   };
 

--- a/packages/hypergraph/src/entity/types.ts
+++ b/packages/hypergraph/src/entity/types.ts
@@ -88,14 +88,14 @@ export type EntityFieldFilter<T> = {
           endsWith?: string;
           contains?: string;
         }
-    : T extends Date
-      ? {
-        is?: Date
-        }
-      : T extends ReadonlyArray<number>
+      : T extends Date
         ? {
-          is?: ReadonlyArray<number>
+            is?: Date;
           }
-      : Record<string, never>);
+        : T extends ReadonlyArray<number>
+          ? {
+              is?: ReadonlyArray<number>;
+            }
+          : Record<string, never>);
 
 export type EntityFilter<T> = CrossFieldFilter<T>;

--- a/packages/hypergraph/src/entity/types.ts
+++ b/packages/hypergraph/src/entity/types.ts
@@ -88,6 +88,14 @@ export type EntityFieldFilter<T> = {
           endsWith?: string;
           contains?: string;
         }
+    : T extends Date
+      ? {
+        is?: Date
+        }
+      : T extends ReadonlyArray<number>
+        ? {
+          is?: ReadonlyArray<number>
+          }
       : Record<string, never>);
 
 export type EntityFilter<T> = CrossFieldFilter<T>;

--- a/packages/hypergraph/test/entity/findMany.test.ts
+++ b/packages/hypergraph/test/entity/findMany.test.ts
@@ -506,3 +506,51 @@ describe('findMany with filters', () => {
     });
   });
 });
+
+describe('Date & Point filters',()=>{
+  class Meetup extends Entity.Class<Meetup>('Meetup')({
+    name:Type.String,
+    when:Type.Date,
+    location:Type.Point,
+  }) {}
+
+  const spaceId = '9a4a5a1b-2c3d-4e5f-8a9b-1234567890ab';
+  const automergeDocId = idToAutomergeId(spaceId) as AnyDocumentId;
+
+  let repo: Repo;
+  let handle: DocHandle<Entity.DocumentContent>;
+
+  beforeEach(()=>{
+    repo = new Repo({});
+    const result = repo.findWithProgress<Entity.DocumentContent>(automergeDocId);
+    handle = result.handle;
+    handle.doneLoading();
+  })
+
+  it('filters by Date is ',()=>{
+    Entity.create(handle,Meetup)({name:'A',when:new Date('2024-01-01T00:00:00Z'),location:[0,0]});
+    Entity.create(handle, Meetup)({ name: 'B', when: new Date('2025-01-01T00:00:00Z'), location: [0, 0] });
+
+    const r = Entity.findMany(
+      handle,
+      Meetup,
+      {when:{is:new Date('2024-01-01T00:00:00Z')}},
+      undefined,
+    );
+    expect(r.entities.map(e=>e.name)).toEqual(['A']);
+  });
+
+  it('filters by Point is ',()=>{
+    Entity.create(handle, Meetup)({ name: 'X', when: new Date('2024-01-01T00:00:00Z'), location: [1, 2] });
+    Entity.create(handle, Meetup)({ name: 'Y', when: new Date('2024-01-01T00:00:00Z'), location: [3, 4] });
+
+    const r = Entity.findMany(
+      handle,
+      Meetup,
+      {location:{is:[1,2]}},
+      undefined
+    );
+    expect(r.entities.map(e=>e.name)).toEqual(['X']);
+  });
+
+});

--- a/packages/hypergraph/test/entity/findMany.test.ts
+++ b/packages/hypergraph/test/entity/findMany.test.ts
@@ -507,11 +507,11 @@ describe('findMany with filters', () => {
   });
 });
 
-describe('Date & Point filters',()=>{
+describe('Date & Point filters', () => {
   class Meetup extends Entity.Class<Meetup>('Meetup')({
-    name:Type.String,
-    when:Type.Date,
-    location:Type.Point,
+    name: Type.String,
+    when: Type.Date,
+    location: Type.Point,
   }) {}
 
   const spaceId = '9a4a5a1b-2c3d-4e5f-8a9b-1234567890ab';
@@ -520,37 +520,26 @@ describe('Date & Point filters',()=>{
   let repo: Repo;
   let handle: DocHandle<Entity.DocumentContent>;
 
-  beforeEach(()=>{
+  beforeEach(() => {
     repo = new Repo({});
     const result = repo.findWithProgress<Entity.DocumentContent>(automergeDocId);
     handle = result.handle;
     handle.doneLoading();
-  })
-
-  it('filters by Date is ',()=>{
-    Entity.create(handle,Meetup)({name:'A',when:new Date('2024-01-01T00:00:00Z'),location:[0,0]});
-    Entity.create(handle, Meetup)({ name: 'B', when: new Date('2025-01-01T00:00:00Z'), location: [0, 0] });
-
-    const r = Entity.findMany(
-      handle,
-      Meetup,
-      {when:{is:new Date('2024-01-01T00:00:00Z')}},
-      undefined,
-    );
-    expect(r.entities.map(e=>e.name)).toEqual(['A']);
   });
 
-  it('filters by Point is ',()=>{
+  it('filters by Date is ', () => {
+    Entity.create(handle, Meetup)({ name: 'A', when: new Date('2024-01-01T00:00:00Z'), location: [0, 0] });
+    Entity.create(handle, Meetup)({ name: 'B', when: new Date('2025-01-01T00:00:00Z'), location: [0, 0] });
+
+    const r = Entity.findMany(handle, Meetup, { when: { is: new Date('2024-01-01T00:00:00Z') } }, undefined);
+    expect(r.entities.map((e) => e.name)).toEqual(['A']);
+  });
+
+  it('filters by Point is ', () => {
     Entity.create(handle, Meetup)({ name: 'X', when: new Date('2024-01-01T00:00:00Z'), location: [1, 2] });
     Entity.create(handle, Meetup)({ name: 'Y', when: new Date('2024-01-01T00:00:00Z'), location: [3, 4] });
 
-    const r = Entity.findMany(
-      handle,
-      Meetup,
-      {location:{is:[1,2]}},
-      undefined
-    );
-    expect(r.entities.map(e=>e.name)).toEqual(['X']);
+    const r = Entity.findMany(handle, Meetup, { location: { is: [1, 2] } }, undefined);
+    expect(r.entities.map((e) => e.name)).toEqual(['X']);
   });
-
 });


### PR DESCRIPTION
Added Date and Point `is` value filters to both private and public queries. 

fixes #440 

Changes Made :-

for private query, 
In `types.ts`, I extended  `EntityFieldFilter<T>` to support `Date` and `ReadonlyArray<number>`.
Another change which i made was in ,
`findMany.ts` , evaluated Date via `getTime()` and Point via [x, y] deep equality.

for public query from what i understood from the codebase was that useQueryPublic already passes $filter and selects time/point, so no extra wiring needed. 

edited `translate-filter-to-graphql.ts` - 
Date → `time: { is: Graph.serializeDate(date) }`
Point → `point: { is: Graph.serializePoint([x, y]) }`

Added a few tests on public & private queries
No breaking changes. Only adds filter capabilities.
Applies only when users provide Date/Point filters.



