### PR TITLE
fix(docs): clarify dev server URL for templates

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -36,7 +36,7 @@ pnpm run dev
 bun run dev
 ```
 
-Open the browser, navigate to `http://localhost:5173` and you should see the app running.
+Open the browser and navigate to the development server URL shown in your terminal (for example, `http://localhost:5173` for Vite or `http://localhost:3000` for Next.js)
 
 ## Example Datasets
 


### PR DESCRIPTION
Updated docs to clarify that the development server URL varies by template. Vite defaults to http://localhost:5173 while Next.js defaults to http://localhost:3000 (or 3001 if 3000 is in use)