### PR TITLE
fix(typesync): remove url type from typesync studio TypeSelect

### DIFF
--- a/.changeset/poor-moons-hunt.md
+++ b/.changeset/poor-moons-hunt.md
@@ -1,0 +1,6 @@
+---
+"@graphprotocol/hypergraph": patch
+---
+
+Removed Url from the TypeSelect in typesync-studio
+  

--- a/packages/hypergraph/src/cli/Cli.ts
+++ b/packages/hypergraph/src/cli/Cli.ts
@@ -11,5 +11,5 @@ const hypergraph = Command.make('hypergraph').pipe(
 
 export const run = Command.run(hypergraph, {
   name: 'hypergraph',
-  version: '0.6.0',
+  version: '0.6.2',
 });

--- a/packages/typesync-studio/src/Components/Schema/TypeSelect.tsx
+++ b/packages/typesync-studio/src/Components/Schema/TypeSelect.tsx
@@ -21,7 +21,6 @@ const typeOptions: ReadonlyArray<TypeOption> = [
   TypeOption.make({ id: 'DefaultEntityNumber', name: 'Number' }),
   TypeOption.make({ id: 'DefaultEntityBoolean', name: 'Boolean' }),
   TypeOption.make({ id: 'DefaultEntityDate', name: 'Date' }),
-  TypeOption.make({ id: 'DefaultEntityUrl', name: 'Url' }),
   TypeOption.make({ id: 'DefaultEntityPoint', name: 'Point' }),
 ];
 


### PR DESCRIPTION
# Description

URL is no longer a supported type